### PR TITLE
make pClientAmiId parameter optional as per the docs

### DIFF
--- a/cloudhsm.yml
+++ b/cloudhsm.yml
@@ -142,6 +142,7 @@ Parameters:
   pClientAmiId:
     Description: ID for EC2 Amazon Machine Image (AMI) for the client instance (Optional. When specified, overrides SSM parameter)
     Type: String
+    Default: ''
 
 Conditions:
   cUseAmiId: !Not [!Equals [ !Ref 'pClientAmiId', '' ] ]


### PR DESCRIPTION
The docs suggest that two subnet parameters and one VPC are enough for the quick start of the template. However, when I create a stack from `cloudhsm.yml` template file, with the following parameters:

```
[
  {
    "ParameterKey": "pSubnets",
    "ParameterValue": "subnet-00000000000000000"
  },
  {
    "ParameterKey": "pClientVpcId",
    "ParameterValue": "vpc-00000000000000000"
  },
  {
    "ParameterKey": "pClientSubnet",
    "ParameterValue": "subnet-00000000000000000"
  }
]
```
, I'm getting the following error `An error occurred (ValidationError) when calling the CreateStack operation: Parameters: [pClientAmiId] must have values`. It appears that the `pClientAmiId` is the only parameter that is marked as optional but doesn't get its own default value. This PR adds it to be a blank string as [line 147](https://github.com/aws-samples/aws-cloudhsm-cloudformation-template/blob/main/cloudhsm.yml#L147) seems to require. I deployed the stack afterwards and it seems to proceed normally for a while (for proper deployment I did have to set a `pClientAmiId` value but that's because the region I use doesn't have t3a instance family so I had to set manual values for type and ami).