### PR TITLE
Added missing tag support to jq command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automated Provisioning of AWS CloudHSM Clusters Using AWS CloudFormation
 
-The `cloudhsm.yml` AWS CloudFormation template automatically provisions an [AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/introduction.html) cluster with HSMs and supporting AWS resources. 
+The `cloudhsm.yml` AWS CloudFormation template automatically provisions an [AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/introduction.html) cluster with HSMs and supporting AWS resources.
 
 The `cloudhsm-key-store.yml` template creates a [CloudHSM key store for KMS](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html) and connects it to a CloudHSM cluster. Instructions for using the `cloudhsm-key-store.yml` template are addressed in [CLOUDHSM-KEY-STORE](./CLOUDHSM-KEY-STORE.md).
 
@@ -8,30 +8,30 @@ These templates are intended to be used for learning and experimentation purpose
 
 You can review an overview of significant changes in the [CHANGELOG](./CHANGELOG.md).
 
-* [Overview](#overview)
-* [Quick start](#quick-start)
-* [Usage](#usage)
-* [Managing security](#managing-security)
-* [Using your own PKI process](#using-your-own-pki-process)
-* [Reviewing template parameters](#reviewing-template-parameters)
-* [Creating the stack](#creating-the-stack)
-* [Troubleshooting stack creation](#troubleshooting-stack-creation)
-* [Performing post stack creation steps](#performing-post-stack-creation-steps)
-* [Updating the stack](#updating-the-stack)
-* [Monitoring and managing the resources](#monitoring-and-managing-the-resources)
-  * [Monitoring and managing the CloudHSM cluster](#monitoring-and-managing-the-cloudhsm-cluster)
-  * [Managing the EC2 client instance](#managing-the-ec2-client-instance)
-  * [Creating a CloudHSM cluster from a backup](#creating-a-cloudhsm-cluster-from-a-backup)
-  * [Saving costs by deleting HSMs](#saving-costs-by-deleting-hsms)
-* [Deleting the stack](#deleting-the-stack)
-* [Creating and managing a CloudHSM key store with AWS KMS](#creating-and-managing-a-cloudhsm-key-store-with-aws-kms)
-* [Notifying of potential security issues](#notifying-of-potential-security-issues)
-* [Contributing](#contributing)
-* [License](#license)
+- [Overview](#overview)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Managing security](#managing-security)
+- [Using your own PKI process](#using-your-own-pki-process)
+- [Reviewing template parameters](#reviewing-template-parameters)
+- [Creating the stack](#creating-the-stack)
+- [Troubleshooting stack creation](#troubleshooting-stack-creation)
+- [Performing post stack creation steps](#performing-post-stack-creation-steps)
+- [Updating the stack](#updating-the-stack)
+- [Monitoring and managing the resources](#monitoring-and-managing-the-resources)
+  - [Monitoring and managing the CloudHSM cluster](#monitoring-and-managing-the-cloudhsm-cluster)
+  - [Managing the EC2 client instance](#managing-the-ec2-client-instance)
+  - [Creating a CloudHSM cluster from a backup](#creating-a-cloudhsm-cluster-from-a-backup)
+  - [Saving costs by deleting HSMs](#saving-costs-by-deleting-hsms)
+- [Deleting the stack](#deleting-the-stack)
+- [Creating and managing a CloudHSM key store with AWS KMS](#creating-and-managing-a-cloudhsm-key-store-with-aws-kms)
+- [Notifying of potential security issues](#notifying-of-potential-security-issues)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Overview
 
-The [`cloudhsm.yml`](cloudhsm.yml) CloudFormation template enables you to create, update, and delete a CloudHSM cluster. 
+The [`cloudhsm.yml`](cloudhsm.yml) CloudFormation template enables you to create, update, and delete a CloudHSM cluster.
 
 The following diagram represents a typical cluster and supporting resources that can be created using this template. The application clients and customer VPC and subnets are outside the scope of this automation.
 
@@ -39,18 +39,18 @@ The following diagram represents a typical cluster and supporting resources that
 
 In addition to a CloudHSM cluster and HSM resources, the following resources are created in support of the cluster:
 
-* A CloudFormation custom resource AWS Lambda function is used to create, update, and delete the CloudHSM cluster
-* AWS Step Functions state machines are used to orchestrate creating, updating, and deleting the CloudHSM cluster
-* Lambda functions are used to support the state machines
-* An Amazon EC2 client instance is configured to activate the cluster and manage users in the HSMs
-* An AWS Systems Manager document is used by steps in the state machines to execute scripts on the EC2 client in support of cluster create and update operations
-* An optional AWS Certificate Manager Private CA private CA and CA certificate are created to optionally issue the cluster certificate
-* AWS Secrets Manager entries are created to support the creation and management of the CloudHSM cluster:
-  * An automatically generated initial crypto officer (CO) `admin` user password 
-  * The cluster's CSR
-  * The customer CA cert under which the cluster cert is issued
-  * The cluster cert in the case where an external PKI process is used to issue the cluster cert
-* IAM service roles are used to support the resources referenced above
+- A CloudFormation custom resource AWS Lambda function is used to create, update, and delete the CloudHSM cluster
+- AWS Step Functions state machines are used to orchestrate creating, updating, and deleting the CloudHSM cluster
+- Lambda functions are used to support the state machines
+- An Amazon EC2 client instance is configured to activate the cluster and manage users in the HSMs
+- An AWS Systems Manager document is used by steps in the state machines to execute scripts on the EC2 client in support of cluster create and update operations
+- An optional AWS Certificate Manager Private CA private CA and CA certificate are created to optionally issue the cluster certificate
+- AWS Secrets Manager entries are created to support the creation and management of the CloudHSM cluster:
+  - An automatically generated initial crypto officer (CO) `admin` user password
+  - The cluster's CSR
+  - The customer CA cert under which the cluster cert is issued
+  - The cluster cert in the case where an external PKI process is used to issue the cluster cert
+- IAM service roles are used to support the resources referenced above
 
 The following diagram shows the AWS services and resources that this templates uses to orchestrate creating, updating, and deleting a CloudHSM cluster:
 
@@ -58,12 +58,12 @@ The following diagram shows the AWS services and resources that this templates u
 
 ## Quick start
 
-* Ensure that the subnet in which the EC2 client will be created has connectivity to the internet in support of package downloads. For example, a private subnet for which routing to the internet via a NAT gateway has been established.
-* Create a new stack and CloudHSM cluster:
-  * Select a VPC
-  * Select at least one of your private subnets for the CloudHSM cluster
-  * Select one of your private subnets for the EC2 client that will be used to help manage your cluster
-  * Leave all other defaults in place
+- Ensure that the subnet in which the EC2 client will be created has connectivity to the internet in support of package downloads. For example, a private subnet for which routing to the internet via a NAT gateway has been established.
+- Create a new stack and CloudHSM cluster:
+  - Select a VPC
+  - Select at least one of your private subnets for the CloudHSM cluster
+  - Select one of your private subnets for the EC2 client that will be used to help manage your cluster
+  - Leave all other defaults in place
 
 ## Usage
 
@@ -83,7 +83,7 @@ Ensure that you're familiar with the basic architecture and operation of [AWS Cl
 
 #### 2. Determine qualifier for cloud resource names
 
-Determine a value for the [`pEnvPurpose`](#reviewing-template-parameters) CloudFormation template parameter that will be used to help qualify the names of many of the cloud resources created by the CloudHSM stack.  If you intend to deploy only one instance of the stack and CloudHSM cluster in the AWS account, then you can use the default value.
+Determine a value for the [`pEnvPurpose`](#reviewing-template-parameters) CloudFormation template parameter that will be used to help qualify the names of many of the cloud resources created by the CloudHSM stack. If you intend to deploy only one instance of the stack and CloudHSM cluster in the AWS account, then you can use the default value.
 
 Many of the resources created by the CloudHSM template will be qualified by a combination of the `pSystem` and `pEnvPurpose` parameter values. Normally, you won't need to override the value of the `pSystem` parameter, but if you intend to manage multiple CloudHSM clusters in the same account, then you will need to use the `pEnvPurpose` parameter to help distinguish the resources used to support the respective clusters. For example, if you create multiple stacks in the same account and in the same Region for testing purposes, then specify values such as `test1` vs `test2` for the `pEnvPurpose` parameter.
 
@@ -93,7 +93,7 @@ If you intend to create multiple CloudHSM clusters in a single AWS account, then
 
 #### 3. Determine the VPC, subnets, and number of HSMs
 
-Determine an existing VPC with which you want the HSMs associated. When you create a cluster, an elastic network interface (ENI) will be created in the subnets that you specify via the `pSubnets` parameter. 
+Determine an existing VPC with which you want the HSMs associated. When you create a cluster, an elastic network interface (ENI) will be created in the subnets that you specify via the `pSubnets` parameter.
 
 Use the `pHsmsPerSubnet` parameter to specify the number of HSMs to create per subnet.
 
@@ -105,14 +105,16 @@ If you intend to connect a KMS CloudHSM key store to the cluster, you'll need to
 
 See [AWS CloudHSM service endpoints](https://docs.aws.amazon.com/general/latest/gr/cloudhsm.html) for the list of regions in which CloudHSM is supported.
 
-AWS CloudHSM might not be available in all Availability Zones in a given Region. 
+AWS CloudHSM might not be available in all Availability Zones in a given Region.
 
 One method of determining the AZs in which CloudHSM is available in a given region is to inspect the results from querying the AZs in which [CloudHSM VPC interface endpoints](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm-vpc-endpoint.html) are available. In the following example, the AZs through which CloudHSM interface endpoints are available in the region `us-east-1` are listed:
 
 ```
 aws ec2 describe-vpc-endpoint-services --service-names com.amazonaws.us-east-1.cloudhsmv2 --region us-east-1 --query 'ServiceDetails[0].AvailabilityZones'
 ```
+
 Resulting in:
+
 ```
 [
     "us-east-1b",
@@ -125,9 +127,11 @@ Resulting in:
 Given the set of AZs in which CloudHSM is available, you can map the AZs to your own subnets. For example, in a particular VPC, the following command will list the subnets and AZ names:
 
 ```
-aws ec2 describe-subnets --filter Name=vpc-id,Values=<vpc ID> | jq -r '.Subnets[]|.SubnetId+" "+.AvailabilityZone+" "+.AvailabilityZoneId+" "+(.Tags[]|select(.Key=="Name").Value)'
+aws ec2 describe-subnets --filter Name=vpc-id,Values=<vpc ID> | jq -r '.Subnets[]|.SubnetId+" "+.AvailabilityZone+" "+.AvailabilityZoneId+" "+ try(select(.Tags[].Key=="Name") | .Tags[].Value) catch "NO TAGS"'
 ```
+
 Resulting in:
+
 ```
 subnet-0f0...07b us-east-1c use1-az4 infra-dev-shared-private-3
 subnet-075...6d7 us-east-1b use1-az2 infra-dev-shared-private-2
@@ -154,6 +158,7 @@ If you'd like to use your own PKI process, you can use set the parameter `pUseEx
 ## Managing security
 
 A security review has been performed on the CloudFormation templates contained in this repository. This solution assumes that CloudHSM cluster will be deployed and managed in the following manner:
+
 - You specify a private subnet that does not support publicly addressable IP addresses to be used for the EC2 client instance
 - You stop (not terminate) the EC2 client instance once management has been completed so that it is normally in the `stopped` state
 - You power on the EC2 client instance to the `running` state when you need to manage the CloudHSM cluster via the EC2 client instance
@@ -179,7 +184,7 @@ PyCQA's [bandit](https://github.com/PyCQA/bandit) static analysis tool has be us
 If you intend to use your own PKI process to issue a cluster certificate, you will first create the stack and then carry out your own PKI process to issue the cluster certificate. After you've issued the cluster certificate, you copy the cluster and CA certificates to already created secrets in AWS Secrets Manager and perform a stack update to complete initialization and activation of the cluster.
 
 1. Create a new stack while selecting `true` for the parameter `pUseExternalPkiProcess`. Doing so will cause the stack creation process to perform only the initial cluster creation steps. Steps that depend on the cluster certificate being available are deferred until you follow the remaining steps.
-2. Obtain the cluster CSR by accessing Secrets Manager. 
+2. Obtain the cluster CSR by accessing Secrets Manager.
 3. Using your own PKI process, issue a cluster certificate. See [Options for testing use of your own PKI process](#options-for-testing-use-of-your-own-pki-process) for examples.
 4. Make your root CA certificate and the newly issued cluster certificate available via Secrets Manager.
 5. Perform an update to your stack. When performing the stack update, set the parameter `pExternallyProvidedCertsReady` to `true` to indicate that the cluster and CA certificates are ready for the stack update process to consume.
@@ -188,11 +193,11 @@ The stack update process will obtain the cluster certificate and CA certificate 
 
 The following secrets are created automatically as part of stack creation. When you use your own PKI process, you'll need to update two of the secrets prior to updating the stack.
 
-|Secrets Manager Secret|Description|
-|---------|--------|
-|`<pSystem>-<cluster ID>-cluster-csr`|When you create a stack, this secret is populated with a CSR for the cluster certificate. If you opted to use your own PKI process, you will use this CSR to issue a cluster certificate.|
-|`<pSystem>-<cluster ID>-cluster-cert`|If you opted to use your own PKI process, you will need to update this secret to represent the plaintext form of the cluster certificate before you perform a stack update. Ensure that you add the certificate as a string rather than binary.|
-|`<pSystem>-<cluster ID>-customer-ca-cert`|If you opted to use your own PKI process, you will need to update this secret to represent the plaintext form of the root CA certificate before you perform a stack update. Ensure that you add the certificate as a string rather than binary.|
+| Secrets Manager Secret                    | Description                                                                                                                                                                                                                                     |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<pSystem>-<cluster ID>-cluster-csr`      | When you create a stack, this secret is populated with a CSR for the cluster certificate. If you opted to use your own PKI process, you will use this CSR to issue a cluster certificate.                                                       |
+| `<pSystem>-<cluster ID>-cluster-cert`     | If you opted to use your own PKI process, you will need to update this secret to represent the plaintext form of the cluster certificate before you perform a stack update. Ensure that you add the certificate as a string rather than binary. |
+| `<pSystem>-<cluster ID>-customer-ca-cert` | If you opted to use your own PKI process, you will need to update this secret to represent the plaintext form of the root CA certificate before you perform a stack update. Ensure that you add the certificate as a string rather than binary. |
 
 ### Options for testing use of your own PKI process
 
@@ -209,7 +214,7 @@ aws secretsmanager get-secret-value --secret-id /cloudhsm/<cluster ID>/cluster-c
 #### Issue the cluster certificate
 
 ```
-aws acm-pca issue-certificate --certificate-authority-arn <CA ARN> --csr fileb://csr.pem --signing-algorithm "SHA256WITHRSA" --validity Value=365,Type="DAYS" 
+aws acm-pca issue-certificate --certificate-authority-arn <CA ARN> --csr fileb://csr.pem --signing-algorithm "SHA256WITHRSA" --validity Value=365,Type="DAYS"
 ```
 
 #### Obtain a copy of the cluster certificate
@@ -226,23 +231,23 @@ aws acm-pca get-certificate --certificate-authority-arn <CA arn> --certificate-a
 
 ## Reviewing template parameters
 
-|Parameter|Required|Description|Default|Supported in Stack Updates?|
-|---------|--------|-----------|-------|---------------------------|
-|`pSystem`|Optional|Used as a prefix in the names of many of the newly created cloud resources. You normally do not need to override the default value.|`cloudhsm`|No|
-|`pEnvPurpose`|Optional|Identifies the purpose for this particular instance of the stack. Used as part of the prefix in the names of many of the newly created resources. Enables you to create and more easily distinguish resources of multiple stacks in the same AWS account. For example, `1`, `2`, `test1`, `test2`, etc.|`1`|No|
-|`pSubnets`|Required|List of subnets to associate with the CloudHSM cluster. Subnets must exists within the same VPC. Only one subnet per availability zone (AZ) may be specified.<br><br>If you're using an AWS region that provides access to more than 3 AZs, ensure that you supply subnet IDs associated with AZs in which CloudHSM is available. See [Determining regions and AZs in which CloudHSM is available](#determining-regions-and-azs-in-which-cloudhsm-is-available) for details.<br><br>Since CloudHSM does not support making changes to the  to the list of subnets after a cluster is created, this template does not support making changes to the list of subnets during stack updates.|None|No|
-|`pHsmsPerSubnet`|Optional|Number of HSMs to create per subnet.<br><br>If you intend to connect a KMS custom key store to the cluster, a minimum of 2 HSMs is required. In the simplest case, to support a KMS custom key store, you could specify one subnet in `pSubnets` and `2` for `pHsmsPerSubnet`.<br><br>See the [AWS CloudHSM Quotas](https://docs.aws.amazon.com/cloudhsm/latest/userguide/limits.html) for the maximum total HSMs you can create per cluster.<br><br>You can modify this parameter during a stack update to either grow or shrink the number of HSMs.<br><br>During a stack update, you can specify `0` to delete all HSMs in the cluster without deleting the cluster. See [Saving costs by deleting HSMs](#saving-costs-by-deleting-hsms).|`1`|Yes|
-|`pHsmType`|Optional|The type of HSM to use in the cluster. Currently the only supported value is `hsm1.medium`|`hsm1.medium`|No|
-|`pUseExternalPkiProcess`|Optional|Select `true` if you want to use your own PKI process to issue a cluster certificate based on the CSR obtained from the cluster creation process. By default, the stack uses AWS Private CA to create a root CA and issue the cluster certificate. See [Determine whether or not you want to use your own PKI process for issuing the cluster certificate](#5-determine-whether-or-not-you-want-to-use-your-own-pki-process-for-issuing-the-cluster-certificate) to help you understand if this option applies to you.|`false`|Yes|
-|`pExternallyProvidedCertsReady`|Optional|Select `true` only if you selected `true` for `pUseExternalPkiProcess` and you've made the necessary certificates available per the process outlined in [Using your own PKI process](#using-your-own-pki-process). This parameter is only processed during stack update operations.<br><br>After you've successfully completed an update based on using your own PKI process, you may leave this parameter set to `true` for subsequent stack updates. The cluster and CA certificates will be processed only once.|`false`|Yes|
-|`pBackupRetentionDays`|Optional|Number of days to retain CloudHSM cluster backups. You may specify from `7` to `379` days.|`90`|No|
-|`pBackupId`|Optional|ID of CloudHSM backup if you want create the cluster from a backup. See [Creating a CloudHSM cluster from a backup](#creating-a-cloudhsm-cluster-from-a-backup).|None|No|
-|`pClientPkg`|Optional|Specify either the CloudHSM client package `cloudhsm-client` or CloudHSM CLI package `cloudhsm-cli` to be installed and configured.<br><br>The CloudHSM client package from the CloudHSM SDK v3 includes the cluster and key management utilities CMU and KMU.<br><br>The CloudHSM CLI package from the CloudHSM SDK v5 does not include the CMU and KMU utilities.|`cloudhsm-client`|Yes<br><br>You can change this option as part of a stack update.|
-|`pClientVpcId`|Required|The VPC in which the EC2 client will be created.|None|No|
-|`pClientSubnet`|Required|The subnet within the VPC specified by `pClientVpcId` in which the EC2 client will be created.|None|Yes<br><br>Causes replacement of the EC2 instance.|
-|`pClientType`|Optional|Instance type to use for the EC2 client|`t3a.small`|Yes<br><br>Does not cause replacement of the EC2 instance.|
-|`pClientAmiSsmParameter`|Optional|SSM parameter name for EC2 AMI to use for the EC2 client.|`/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs`|No|
-|`pClientAmiId`|Optional|ID of EC2 AMI to use for the EC2 client.<br><br>Overrides `pClientAmiSsmParameter` when present.<br><br>If you desire to have direct control over the AMI in use, specify this parameter.|None|Yes<br><br>Causes replacement of the EC2 instance.|
+| Parameter                       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Default                                                         | Supported in Stack Updates?                                      |
+| ------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `pSystem`                       | Optional | Used as a prefix in the names of many of the newly created cloud resources. You normally do not need to override the default value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `cloudhsm`                                                      | No                                                               |
+| `pEnvPurpose`                   | Optional | Identifies the purpose for this particular instance of the stack. Used as part of the prefix in the names of many of the newly created resources. Enables you to create and more easily distinguish resources of multiple stacks in the same AWS account. For example, `1`, `2`, `test1`, `test2`, etc.                                                                                                                                                                                                                                                                                                                                                                                                                                      | `1`                                                             | No                                                               |
+| `pSubnets`                      | Required | List of subnets to associate with the CloudHSM cluster. Subnets must exists within the same VPC. Only one subnet per availability zone (AZ) may be specified.<br><br>If you're using an AWS region that provides access to more than 3 AZs, ensure that you supply subnet IDs associated with AZs in which CloudHSM is available. See [Determining regions and AZs in which CloudHSM is available](#determining-regions-and-azs-in-which-cloudhsm-is-available) for details.<br><br>Since CloudHSM does not support making changes to the to the list of subnets after a cluster is created, this template does not support making changes to the list of subnets during stack updates.                                                      | None                                                            | No                                                               |
+| `pHsmsPerSubnet`                | Optional | Number of HSMs to create per subnet.<br><br>If you intend to connect a KMS custom key store to the cluster, a minimum of 2 HSMs is required. In the simplest case, to support a KMS custom key store, you could specify one subnet in `pSubnets` and `2` for `pHsmsPerSubnet`.<br><br>See the [AWS CloudHSM Quotas](https://docs.aws.amazon.com/cloudhsm/latest/userguide/limits.html) for the maximum total HSMs you can create per cluster.<br><br>You can modify this parameter during a stack update to either grow or shrink the number of HSMs.<br><br>During a stack update, you can specify `0` to delete all HSMs in the cluster without deleting the cluster. See [Saving costs by deleting HSMs](#saving-costs-by-deleting-hsms). | `1`                                                             | Yes                                                              |
+| `pHsmType`                      | Optional | The type of HSM to use in the cluster. Currently the only supported value is `hsm1.medium`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | `hsm1.medium`                                                   | No                                                               |
+| `pUseExternalPkiProcess`        | Optional | Select `true` if you want to use your own PKI process to issue a cluster certificate based on the CSR obtained from the cluster creation process. By default, the stack uses AWS Private CA to create a root CA and issue the cluster certificate. See [Determine whether or not you want to use your own PKI process for issuing the cluster certificate](#5-determine-whether-or-not-you-want-to-use-your-own-pki-process-for-issuing-the-cluster-certificate) to help you understand if this option applies to you.                                                                                                                                                                                                                       | `false`                                                         | Yes                                                              |
+| `pExternallyProvidedCertsReady` | Optional | Select `true` only if you selected `true` for `pUseExternalPkiProcess` and you've made the necessary certificates available per the process outlined in [Using your own PKI process](#using-your-own-pki-process). This parameter is only processed during stack update operations.<br><br>After you've successfully completed an update based on using your own PKI process, you may leave this parameter set to `true` for subsequent stack updates. The cluster and CA certificates will be processed only once.                                                                                                                                                                                                                          | `false`                                                         | Yes                                                              |
+| `pBackupRetentionDays`          | Optional | Number of days to retain CloudHSM cluster backups. You may specify from `7` to `379` days.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | `90`                                                            | No                                                               |
+| `pBackupId`                     | Optional | ID of CloudHSM backup if you want create the cluster from a backup. See [Creating a CloudHSM cluster from a backup](#creating-a-cloudhsm-cluster-from-a-backup).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | None                                                            | No                                                               |
+| `pClientPkg`                    | Optional | Specify either the CloudHSM client package `cloudhsm-client` or CloudHSM CLI package `cloudhsm-cli` to be installed and configured.<br><br>The CloudHSM client package from the CloudHSM SDK v3 includes the cluster and key management utilities CMU and KMU.<br><br>The CloudHSM CLI package from the CloudHSM SDK v5 does not include the CMU and KMU utilities.                                                                                                                                                                                                                                                                                                                                                                          | `cloudhsm-client`                                               | Yes<br><br>You can change this option as part of a stack update. |
+| `pClientVpcId`                  | Required | The VPC in which the EC2 client will be created.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | None                                                            | No                                                               |
+| `pClientSubnet`                 | Required | The subnet within the VPC specified by `pClientVpcId` in which the EC2 client will be created.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | None                                                            | Yes<br><br>Causes replacement of the EC2 instance.               |
+| `pClientType`                   | Optional | Instance type to use for the EC2 client                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `t3a.small`                                                     | Yes<br><br>Does not cause replacement of the EC2 instance.       |
+| `pClientAmiSsmParameter`        | Optional | SSM parameter name for EC2 AMI to use for the EC2 client.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | `/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs` | No                                                               |
+| `pClientAmiId`                  | Optional | ID of EC2 AMI to use for the EC2 client.<br><br>Overrides `pClientAmiSsmParameter` when present.<br><br>If you desire to have direct control over the AMI in use, specify this parameter.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | None                                                            | Yes<br><br>Causes replacement of the EC2 instance.               |
 
 ## Creating the stack
 
@@ -259,17 +264,18 @@ Typically, creation of the stack will take ~10 to ~20 minutes depending on the n
 The general order in which cloud resources are created is as follows:
 
 The general order in which cloud resources are created is as follows:
-* IAM service role and EC2 instance profile for the EC2 client instance
-* EC2 client instance
-*   An EC2 UserData script is used in conjunction with [`AWS::CloudFormation::Init`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html) to bootstrap the CloudHSM client instance
-      * CloudWatch agent is configured
-      * Package dependencies are installed
-      * Several scripts are generated for subsequent execution from the state machines
-* IAM service roles for AWS StepFunctions and Lambda functions
-* Lambda functions to support StepFunction state machines
-* StepFunction state machines
-* CloudFormation Custom resource Lambda function
-* CloudHSM cluster and the first HSMs
+
+- IAM service role and EC2 instance profile for the EC2 client instance
+- EC2 client instance
+- An EC2 UserData script is used in conjunction with [`AWS::CloudFormation::Init`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html) to bootstrap the CloudHSM client instance
+  - CloudWatch agent is configured
+  - Package dependencies are installed
+  - Several scripts are generated for subsequent execution from the state machines
+- IAM service roles for AWS StepFunctions and Lambda functions
+- Lambda functions to support StepFunction state machines
+- StepFunction state machines
+- CloudFormation Custom resource Lambda function
+- CloudHSM cluster and the first HSMs
 
 ### 3. Inspect the created resources
 
@@ -278,15 +284,17 @@ Once the stack has been created, you can tour the environment to review the clou
 #### Inspect CloudHSM cluster
 
 Access the CloudHSM console to view the CloudHSM cluster and HSMs.
-* The state of the cluster and the associated HSM(s) should be `Active`
-* Note the ENI IP address(es), AZs, and subnets in use
-* Selecting `Backups` will show several backups already created due to the fact that changes were made to the cluster during initial provisioning
+
+- The state of the cluster and the associated HSM(s) should be `Active`
+- Note the ENI IP address(es), AZs, and subnets in use
+- Selecting `Backups` will show several backups already created due to the fact that changes were made to the cluster during initial provisioning
 
 #### Inspect contents of Secrets Manager
 
 Access the Secrets Manager console to view the generated secrets associated with the cluster.
-* Initial crypto officer password
-* Customer CA certificate used to connect the EC2 client instance to the cluster
+
+- Initial crypto officer password
+- Customer CA certificate used to connect the EC2 client instance to the cluster
 
 #### Inspect Elastic Network Interfaces (ENIs)
 
@@ -296,20 +304,23 @@ Access the EC2 console and select Network Interfaces to inspect the ENIs that we
 
 **CloudHSM client: Using the CloudHSM Management Utility (CMU)**
 
-By default the CloudHSM client package from the CloudHSM SDK v3 is installed. The EC2 client instance has been configured with the [CloudHSM Management Utility (CMU)](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm_mgmt_util.html) to support ongoing inspection and configuration of your cluster.  You can use the `cloudhsm_mgmt_util` CLI to execute the CMU.
+By default the CloudHSM client package from the CloudHSM SDK v3 is installed. The EC2 client instance has been configured with the [CloudHSM Management Utility (CMU)](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm_mgmt_util.html) to support ongoing inspection and configuration of your cluster. You can use the `cloudhsm_mgmt_util` CLI to execute the CMU.
 
 Use AWS Systems Manager Session Manager to access a terminal session to the EC2 client instance. See [Monitoring EC2 client instance configuration](#monitoring-ec2-client-instance-configuration) for details.
 
 Once you're in the terminal session, execute:
+
 ```
 /opt/cloudhsm/bin/cloudhsm_mgmt_util /opt/cloudhsm/etc/cloudhsm_mgmt_util.cfg
 ```
+
 For each HSM, you should see a connection being established.
 
 A subset of the [CMU commands](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm_mgmt_util-reference.html) can be executed before logging in. For example:
-  * `getHSMInfo` - Lists details of each HSM
-  * `listUsers` - Lists users defined on each HSM. The set of users should be identical across HSMs.
-  * `info server 0` - List details of each HSM. Replace `0` with the index of the HSM of interest.
+
+- `getHSMInfo` - Lists details of each HSM
+- `listUsers` - Lists users defined on each HSM. The set of users should be identical across HSMs.
+- `info server 0` - List details of each HSM. Replace `0` with the index of the HSM of interest.
 
 **CloudHSM CLI: Using CloudHSM CLI**
 
@@ -318,29 +329,32 @@ If you opted to install the CloudHSM CLI from the CloudHSM SDK v5, the EC2 clien
 Use AWS Systems Manager Session Manager to access a terminal session to the EC2 client instance. See [Monitoring EC2 client instance configuration](#monitoring-ec2-client-instance-configuration) for details.
 
 Once you're in the terminal session, execute:
+
 ```
 /opt/cloudhsm/bin/cloudhsm-cli interactive
 ```
+
 A subset of the [commands](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm_cli-reference.html) can be executed before logging in. For example:
+
 ```
 aws-cloudhsm > user list
 ```
 
 ## Troubleshooting stack creation
 
-By default, when issues occur during stack creation, CloudFormation will attempt to rollback the changes by deleting the resources created up to the point of the failure. You can preserve the state of a failed stack creation attempt by creating the stack with the option to disable rollback on stack creation failure. If the resources have been rolled back and deleted, you won't have the opportunity to inspect the resources for the cause of the failure. 
+By default, when issues occur during stack creation, CloudFormation will attempt to rollback the changes by deleting the resources created up to the point of the failure. You can preserve the state of a failed stack creation attempt by creating the stack with the option to disable rollback on stack creation failure. If the resources have been rolled back and deleted, you won't have the opportunity to inspect the resources for the cause of the failure.
 
-In this situation, you should delete the stack and attempt to create a new stack with an option to preserve successfully provisioned resources. When creating a stack again, in the CloudFormation console, in "Stack failure options", select "Preserve successfully provisioned resources". 
+In this situation, you should delete the stack and attempt to create a new stack with an option to preserve successfully provisioned resources. When creating a stack again, in the CloudFormation console, in "Stack failure options", select "Preserve successfully provisioned resources".
 
 ### `rClientInstance` creation failure
 
 If you notice that stack creation fails on creation of the `rClientInstance` EC2 client instance resource, you should verify that the subnet in which the EC2 instance has been created has connectivity to the internet. Since the EC2 client needs to download several packages and access AWS service APIs during first boot, internet connectivity is required.
 
-If you've verified that the EC2 client has connectivity to the internet, you should inspect the content of the `/var/log/cfn-init.log` log file produced by the EC2 client instance. 
+If you've verified that the EC2 client has connectivity to the internet, you should inspect the content of the `/var/log/cfn-init.log` log file produced by the EC2 client instance.
 
-Use AWS Systems Manager Session Manager to access a terminal session to the EC2 client instance. In the EC2 console, you'll see an instance named based on the the `pSystem` and `pEnvPurpose` parameters. You can select that instance, select `Connect`, select `Session Manager`, and select `Connect` in an attempt to access a terminal session of the instance. 
+Use AWS Systems Manager Session Manager to access a terminal session to the EC2 client instance. In the EC2 console, you'll see an instance named based on the the `pSystem` and `pEnvPurpose` parameters. You can select that instance, select `Connect`, select `Session Manager`, and select `Connect` in an attempt to access a terminal session of the instance.
 
-If the EC2 client's first boot progressed to a sufficient point, you should also be able to review the content of the `/var/log/cfn-init.log` via the CloudWatch console. 
+If the EC2 client's first boot progressed to a sufficient point, you should also be able to review the content of the `/var/log/cfn-init.log` via the CloudWatch console.
 
 ### `rCloudHsmCluster` creation failure
 
@@ -352,11 +366,11 @@ In the CloudWatch Logs console, you can review the output of the `...-create-clu
 
 ### Changing the crypto officer password
 
-As a security best practice, you should change the Crypto Officer (CO) password immediately after the stack is created. 
+As a security best practice, you should change the Crypto Officer (CO) password immediately after the stack is created.
 
 **CloudHSM client: Using the CloudHSM Management Utility (CMU)**
 
-By default the CloudHSM client package from the CloudHSM SDK v3 is installed. The EC2 client instance has been configured with CloudHSM SDK v3 that includes the [CloudHSM Management Utility (CMU)](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm_mgmt_util.html) to support ongoing inspection and configuration of your cluster.  You can use the `cloudhsm_mgmt_util` CLI to execute the CMU.
+By default the CloudHSM client package from the CloudHSM SDK v3 is installed. The EC2 client instance has been configured with CloudHSM SDK v3 that includes the [CloudHSM Management Utility (CMU)](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm_mgmt_util.html) to support ongoing inspection and configuration of your cluster. You can use the `cloudhsm_mgmt_util` CLI to execute the CMU.
 
 Use AWS Systems Manager Session Manager to access a terminal session to the EC2 client instance. See [Monitoring EC2 client instance configuration](#monitoring-ec2-client-instance-configuration) for details.
 
@@ -364,21 +378,27 @@ Once you're in the terminal session:
 
 1. Obtain the initial crypto officer (CO) password from Secrets Manager
 2. Execute:
+
 ```
 /opt/cloudhsm/bin/cloudhsm_mgmt_util /opt/cloudhsm/etc/cloudhsm_mgmt_util.cfg
 ```
+
 For each HSM, you should see a connection being established.
 
-3. At the `aws-cloudhsm>` prompt, log in via the CO `admin` user:  
+3. At the `aws-cloudhsm>` prompt, log in via the CO `admin` user:
+
 ```
 aws-cloudhsm>loginHSM CO admin -hpswd
 ```
+
 4. Enter the initial password for the CO user that you obtained from Secrets Manager
 5. You should see a successful login for each HSM.
 6. Change the password:
+
 ```
 aws-cloudhsm>changePswd CO admin -hpswd
 ```
+
 7. Specify the password
 8. Enter `quit` to exit the CMU
 
@@ -398,19 +418,25 @@ Once you're in the terminal session:
 
 1. Obtain the initial crypto officer (CO) password from Secrets Manager
 2. Execute:
+
 ```
 /opt/cloudhsm/bin/cloudhsm-cli interactive
 ```
+
 3. Log in via the CO/admin user:
+
 ```
 aws-cloudhsm > login --username admin --role admin
 ```
+
 4. Enter the initial password for the CO user that you obtained from Secrets Manager
 5. You should see a successful login
 6. Change the password:
+
 ```
 aws-cloudhsm > user change-password --username admin --role admin
 ```
+
 7. Specify the password
 8. Enter `quit` to exit the CLI
 
@@ -422,7 +448,7 @@ If you requested creation of a KMS custom key store, KMS has already changed the
 
 ## Updating the stack
 
-The CloudFormation template currently supports a limited number of template parameters that can be applied via CloudFormation stack updates.  See [CloudFormation Template Parameters](#reviewing-template-parameters) for the stack parameters that can be updated.
+The CloudFormation template currently supports a limited number of template parameters that can be applied via CloudFormation stack updates. See [CloudFormation Template Parameters](#reviewing-template-parameters) for the stack parameters that can be updated.
 
 ## Monitoring and managing the resources
 
@@ -430,8 +456,8 @@ The CloudFormation template currently supports a limited number of template para
 
 See the following resources for information on monitoring and managing your CloudHSM cluster:
 
-* [Monitoring AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/get-logs.html)
-* [Managing Backups](https://docs.aws.amazon.com/cloudhsm/latest/userguide/manage-backups.html)
+- [Monitoring AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/get-logs.html)
+- [Managing Backups](https://docs.aws.amazon.com/cloudhsm/latest/userguide/manage-backups.html)
 
 ### Managing the EC2 client instance
 
@@ -451,7 +477,7 @@ If you specified an AMI ID during stack creation, you can perform a stack update
 
 During the stack update process, CloudFormation will create a new EC2 client instance. The first boot automation process in the new EC2 client instance will recognize the presence of the previously generated customer CA certificate in Secrets Manager and use the certificate to help configure the client instance. Once the new EC2 client instance has been created, CloudFormation will terminate the old EC2 client instance.
 
-You can also force replacement of the EC2 client instance by specifying a different subnet during a stack update.  
+You can also force replacement of the EC2 client instance by specifying a different subnet during a stack update.
 
 #### Addressing a terminated EC2 client instance
 
@@ -459,7 +485,7 @@ If the EC2 client was terminated outside of a stack delete operation, you can us
 
 ### Creating a CloudHSM cluster from a backup
 
-The CloudFormation template supports the ability to create a new CloudHSM cluster from a backup.  As long as at least one backup from a cluster exists, you can create a new stack while specifying the ID of the backup of interest. If you specify a valid backup ID via the parameter `pBackupId` during stack creation, the stack creation process will use the specified backup to create a new cluster.
+The CloudFormation template supports the ability to create a new CloudHSM cluster from a backup. As long as at least one backup from a cluster exists, you can create a new stack while specifying the ID of the backup of interest. If you specify a valid backup ID via the parameter `pBackupId` during stack creation, the stack creation process will use the specified backup to create a new cluster.
 
 If you're creating a new cluster from a backup with which a KMS custom key store was previously connected, ensure that the backup you select contains the KMS key data that you require to be present in your newly created cluster.
 
@@ -471,7 +497,7 @@ If you have a non-production cluster that doesn't need to be used at all times, 
 
 #### Delete all HSMs without deleting a cluster
 
-To delete all HSMs without deleting a cluster, set the `pHsmsPerSubnet` parameter to `0` during a stack update. 
+To delete all HSMs without deleting a cluster, set the `pHsmsPerSubnet` parameter to `0` during a stack update.
 
 Since CloudHSM makes a backup of the cluster when an HSM is removed, you'll have an up-to-date cluster backup that will be used when you create new HSMs. See [Managing AWS CloudHSM backups](https://docs.aws.amazon.com/cloudhsm/latest/userguide/manage-backups.html.)
 

--- a/README.md
+++ b/README.md
@@ -263,8 +263,6 @@ Typically, creation of the stack will take ~10 to ~20 minutes depending on the n
 
 The general order in which cloud resources are created is as follows:
 
-The general order in which cloud resources are created is as follows:
-
 - IAM service role and EC2 instance profile for the EC2 client instance
 - EC2 client instance
 - An EC2 UserData script is used in conjunction with [`AWS::CloudFormation::Init`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html) to bootstrap the CloudHSM client instance


### PR DESCRIPTION
*Issue #, if available:*
If a subnet in a VPC did not have a Name tag, the null value would cause the jq command in the README file to throw an error.

*Description of changes:*
Added null handling to the jq command at line 130 so that if the user has not tagged their subnets the jq command will still run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
