### PR TITLE
Cross-Region Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,15 @@ If you're creating a new cluster from a backup with which a KMS custom key store
 
 Since a CloudHSM backup retains the state of a cluster, creating a new cluster using a backup does not require initialization and activation of the newly created cluster. As part of the stack creation process and after the cluster is restored from the specified backup, the number of HSMs per subnet that you specified when creating the new stack will be created.
 
+Before deploying this solution you need first to create a Secrets Manager entry with the Customer CA Certificate of the backed-up CloudHSM cluster:
+Entry: /<pSystem>/<Source Cluster ID>/customer-ca-cert for backups accross regions and /<pSystem>/<Cluster ID>/customer-ca-cert for backups from the same region.
+Value: 
+-----BEGIN CERTIFICATE-----
+MIIFgjCCA2qgAwIBA...............................................
+................................................................
+................................................................
+-----END CERTIFICATE-----
+
 ### Saving costs by deleting HSMs
 
 If you have a non-production cluster that doesn't need to be used at all times, you can perform a stack update to delete all of the HSMs without deleting the cluster. Later, when you need to use the cluster, you can perform a stack update to recreate the number of HSMs of interest. By retaining the original cluster, you can avoid the process of creating a new cluster including issuing a cluster certificate.

--- a/cloudhsm.yml
+++ b/cloudhsm.yml
@@ -1965,7 +1965,11 @@ Resources:
             system_id = event['ResourceProperties']['SystemId']
 
             cluster_resp = cloudhsm.describe_backups(Filters={'backupIds': [backup_id]})
-            backup_cluster_id = cluster_resp['Backups'][0]['ClusterId']
+
+            try:
+              backup_cluster_id = cluster_resp['Backups'][0]['ClusterId']
+            except KeyError: 
+              backup_cluster_id = cluster_resp['Backups'][0]['SourceCluster']
 
             backup_secret_id = f'/{system_id}/{backup_cluster_id}/customer-ca-cert'
             secret_value = sm.get_secret_value(SecretId=backup_secret_id)


### PR DESCRIPTION
- Added to the rLambdaRetrievePriorCaCert a check for SourceCluster
- Updated documentation to include before restoring backup to create the new Secrets Manager with the Customer CA Certificate of the backed-up CloudHSM cluster Entry: /<pSystem>/<Source Cluster ID>/customer-ca-cert for backups accross regions and /<pSystem>/<Cluster ID>/customer-ca-cert for backups from the same region.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
